### PR TITLE
fix: strip comments from theme file to fix loading

### DIFF
--- a/themes/claude-desktop-dark
+++ b/themes/claude-desktop-dark
@@ -1,10 +1,3 @@
-# Claude Desktop Dark — Ghostty Theme
-# Inspired by the Claude AI desktop app (claude.ai) dark mode interface
-# Warm dark brown background with cream text and terracotta accents
-#
-# Repository: https://github.com/steavenpm/ghostty-claude-theme
-# License: MIT
-
 background = #2B2523
 foreground = #E8DDD3
 cursor-color = #D97757
@@ -12,7 +5,6 @@ cursor-text = #2B2523
 selection-background = #4A3F3A
 selection-foreground = #E8DDD3
 
-# Normal colors (0-7)
 palette = 0=#2B2523
 palette = 1=#E06C75
 palette = 2=#98C379
@@ -22,7 +14,6 @@ palette = 5=#C678DD
 palette = 6=#56B6C2
 palette = 7=#E8DDD3
 
-# Bright colors (8-15)
 palette = 8=#4A3F3A
 palette = 9=#FF8A80
 palette = 10=#A8D98A


### PR DESCRIPTION
## Summary
- Removes comment headers (including UTF-8 em dash) from theme file that caused Ghostty's parser to silently reject it
- Theme file now matches the working local version: key=value pairs only
- Fixes fresh installs showing default grey background instead of #2B2523

Fixes #1

## Test plan
- [ ] Run `bash install.sh` locally, choose option 1, restart Ghostty — background should be brown (#2B2523)
- [ ] Run via `bash <(curl -fsSL ...)` on a clean machine — same result
- [ ] Verify all 16 palette colors render correctly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>