### PR TITLE
fix: handle macOS dual config that overrides theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ The script detects which mode by checking if theme files exist at the resolved p
 - **BSD sed/grep** (macOS): never use `\s` — use `[[:space:]]` instead
 - **Process substitution**: `bash <(curl ...)` sets `BASH_SOURCE[0]` to `/dev/fd/XX`, not a real path
 - **Ghostty config keys**: verify against https://ghostty.org/docs/config/reference — invalid keys are silently ignored (e.g. `background-blur-radius` is wrong, `background-blur` is correct)
+- **macOS dual config**: Ghostty reads from BOTH `~/.config/ghostty/config` AND `~/Library/Application Support/com.mitchellh.ghostty/config`. A `theme=` line in the latter overrides the former. The install script must check and handle both locations.
 
 ## Editing the Theme
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 GHOSTTY_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty"
 GHOSTTY_THEMES_DIR="$GHOSTTY_CONFIG_DIR/themes"
 GHOSTTY_CONFIG_FILE="$GHOSTTY_CONFIG_DIR/config"
+# macOS also reads config from Application Support — a theme set there overrides ours
+GHOSTTY_MACOS_CONFIG="$HOME/Library/Application Support/com.mitchellh.ghostty/config"
 BACKUP_SUFFIX=".backup.$(date +%Y%m%d%H%M%S)"
 BACKUP_CREATED=false
 
@@ -60,6 +62,22 @@ if ! command -v ghostty &>/dev/null; then
     echo ""
 fi
 
+# ── Handle macOS Application Support config ──
+# Ghostty on macOS reads from both ~/.config/ghostty/config AND
+# ~/Library/Application Support/com.mitchellh.ghostty/config.
+# A theme= line in the latter overrides the former, so we need to
+# comment it out to prevent conflicts.
+fix_macos_config() {
+    if [[ -f "$GHOSTTY_MACOS_CONFIG" ]] && grep -q "^theme[[:space:]]*=" "$GHOSTTY_MACOS_CONFIG" 2>/dev/null; then
+        warn "Found conflicting theme in macOS Ghostty config:"
+        warn "  $GHOSTTY_MACOS_CONFIG"
+        cp "$GHOSTTY_MACOS_CONFIG" "${GHOSTTY_MACOS_CONFIG}${BACKUP_SUFFIX}"
+        sed -i.tmp 's/^theme[[:space:]]*=.*$/# &  # commented by ghostty-claude-theme installer/' "$GHOSTTY_MACOS_CONFIG"
+        rm -f "${GHOSTTY_MACOS_CONFIG}.tmp"
+        ok "Commented out conflicting theme (backup saved)"
+    fi
+}
+
 # ── Create directories ──
 mkdir -p "$GHOSTTY_THEMES_DIR"
 
@@ -93,6 +111,7 @@ case "$choice" in
         fi
         cp "$SCRIPT_DIR/config/ghostty.conf" "$GHOSTTY_CONFIG_FILE"
         ok "Full config applied"
+        fix_macos_config
         ;;
     2)
         if [[ -f "$GHOSTTY_CONFIG_FILE" ]]; then
@@ -111,6 +130,7 @@ case "$choice" in
             echo "theme = claude-desktop-dark" > "$GHOSTTY_CONFIG_FILE"
             ok "Created config with theme"
         fi
+        fix_macos_config
         ;;
     3)
         ok "Skipped config. Set theme = claude-desktop-dark in your Ghostty config."


### PR DESCRIPTION
## Summary
- Ghostty on macOS reads config from **two** locations: `~/.config/ghostty/config` and `~/Library/Application Support/com.mitchellh.ghostty/config`
- A `theme=` line in the Application Support config silently overrides the one in `~/.config/ghostty/config`
- The installer now detects this conflict, backs up the file, and comments out the conflicting theme line

## Root cause
Our install script only wrote to `~/.config/ghostty/config`. Users who had previously set a theme via Ghostty's built-in settings UI (which writes to Application Support) would see their old theme instead of claude-desktop-dark. All other config settings (opacity, blur, cursor) applied correctly because they had no conflict.

Fixes #1

## Test plan
- [ ] Restore the broken state on test machine (uncomment `theme = Gruvbox Material` in Application Support config)
- [ ] Run `bash <(curl -fsSL https://raw.githubusercontent.com/steavenpm/ghostty-claude-theme/fix/macos-dual-config/install.sh)`
- [ ] Verify installer shows warning about conflicting theme and comments it out
- [ ] Restart Ghostty — background should be brown (#2B2523)
- [ ] Verify backup was created in Application Support directory

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>